### PR TITLE
Update ModelBase.py

### DIFF
--- a/models/ModelBase.py
+++ b/models/ModelBase.py
@@ -189,9 +189,16 @@ class ModelBase(object):
         return []
 
     #overridable   
-    def get_model_name(self):
+    def get_model_name(self):                    
+        try:
+            return self._model_name
+        except AttributeError:
+            ## this will effectively give you your model name all the time
+            self._model_name = os.path.split(__file__)[0].rsplit("_", 1)[1]
+        return self._model_name             
+    
         #also used as prefix for model files
-        return "ModelBase"
+        #return "ModelBase"
         
     #overridable
     def get_converter(self, **in_options):


### PR DESCRIPTION
Just for lulz to make this "Abstract" class more useful. Your **get_model_name** method will actually give you a model name all the time. You don't need to "override" it in children at all. In fact you should make it as a static method or a **property**.